### PR TITLE
Fix __hash_ulc not working on perl 5.20

### DIFF
--- a/lib/Data/Tools.pm
+++ b/lib/Data/Tools.pm
@@ -249,12 +249,13 @@ sub __hash_ulc
   my $ipl = shift;
   
   my $nr = $ipl ? $hr : {};
-  while( my ( $k, $v ) = each %$hr )
+  for my $k ( keys %$hr )
     {
+    my $v = $hr->{ $k };
     my $old_k = $k;
     $k = $uc ? uc( $k ) : lc( $k );
     $nr->{ $k } = $v;
-    delete $nr->{ $old_k } if $ipl and $k ne $old_k;
+    delete $nr->{ $old_k } if ($ipl and $k ne $old_k);
     }
   return $nr;  
 }


### PR DESCRIPTION
 Use of each() on hash after insertion without resetting hash iterator results in undefined behavior,
 Perl interpreter: 0x11f0010 at lib/Data/Tools.pm line 252.